### PR TITLE
Set cache to false in lint job

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1.20.3
+          cache: false # by golangci-lint-action
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2


### PR DESCRIPTION
To avoid conflict with golangci/golangci-lint-action@v3.