### PR TITLE
Notify deadline exceeded error on subscription creation

### DIFF
--- a/api/v1/subscription_types.go
+++ b/api/v1/subscription_types.go
@@ -23,15 +23,19 @@ import (
 // SubscriptionSpec defines the desired state of Subscription
 type SubscriptionSpec struct {
 	// subscription ID
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	SubscriptionID string `json:"subscriptionID,omitempty"`
 
 	// project ID of subscription
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	SubscriptionProjectID string `json:"subscriptionProjectID,omitempty"`
 
 	// topic ID
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	TopicID string `json:"topicID,omitempty"`
 
 	// project ID of topic
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	TopicProjectID string `json:"topicProjectID,omitempty"`
 }
 

--- a/api/v1/topic_types.go
+++ b/api/v1/topic_types.go
@@ -23,9 +23,11 @@ import (
 // TopicSpec defines the desired state of Topic
 type TopicSpec struct {
 	// ID of project
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	ProjectID string `json:"projectID,omitempty"`
 
 	// ID of topic
+	//+kubebuilder:validation:XValidation:message="Immutable field",rule="self == oldSelf"
 	TopicID string `json:"topicID,omitempty"`
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,8 @@ import (
 	"os"
 
 	"cloud.google.com/go/pubsub"
+	"k8s.io/utils/clock"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -106,6 +108,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		NewClient: pubsub.NewClient,
 		Recorder:  mgr.GetEventRecorderFor("subscription-controller"),
+		Clock:     clock.RealClock{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Subscription")
 		os.Exit(1)

--- a/config/crd/bases/googlecloudpubsuboperator.quipper.github.io_subscriptions.yaml
+++ b/config/crd/bases/googlecloudpubsuboperator.quipper.github.io_subscriptions.yaml
@@ -37,15 +37,27 @@ spec:
               subscriptionID:
                 description: subscription ID
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
               subscriptionProjectID:
                 description: project ID of subscription
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
               topicID:
                 description: topic ID
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
               topicProjectID:
                 description: project ID of topic
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
             type: object
           status:
             description: SubscriptionStatus defines the observed state of Subscription

--- a/config/crd/bases/googlecloudpubsuboperator.quipper.github.io_topics.yaml
+++ b/config/crd/bases/googlecloudpubsuboperator.quipper.github.io_topics.yaml
@@ -37,9 +37,15 @@ spec:
               projectID:
                 description: ID of project
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
               topicID:
                 description: ID of topic
                 type: string
+                x-kubernetes-validations:
+                - message: Immutable field
+                  rule: self == oldSelf
             type: object
           status:
             description: TopicStatus defines the observed state of Topic

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/api v0.28.4
 	k8s.io/apimachinery v0.28.4
 	k8s.io/client-go v0.28.4
+	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/controller-runtime v0.15.1
 )
 
@@ -82,7 +83,6 @@ require (
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
@@ -29,6 +30,7 @@ import (
 	"google.golang.org/api/option"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -113,6 +115,8 @@ var _ = BeforeSuite(func() {
 		Scheme:    k8sManager.GetScheme(),
 		NewClient: newClient,
 		Recorder:  k8sManager.GetEventRecorderFor("subscription-controller"),
+		// TODO: how to change the time in test code?
+		Clock: clocktesting.NewFakePassiveClock(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Problem to solve
Currently, we get the following warning events:

> SubscriptionCreateError: Failed to create Subscription in Pub/Sub: CreateSubscription: rpc error: code = NotFound desc = Resource not found (resource=...)
> Events emitted by the subscription-controller seen at 2023-11-30 03:31:04 +0000 UTC since 2023-11-30 03:31:04 +0000 UTC

If a subscription is creating before the topic, it fails but will succeed after retrying. It would be nice if we get only the deadline exceeded errors.

## How to solve
Notify an error if the deadline is exceeded, i.e., `Now - CreationTimestamp > Deadline`.
