### PR TITLE
Revert to Go 1.21

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.21.7
           cache: false # by golangci-lint-action
       - uses: golangci/golangci-lint-action@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.21.7
       - run: go mod tidy
       - run: make fmt
       - run: make generate manifests
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.21.7
       - run: make test


### PR DESCRIPTION
The mainline has been broken since https://github.com/quipper/google-cloud-pubsub-operator/pull/214. Revert it.
